### PR TITLE
Add elegant theme toggle and build log page

### DIFF
--- a/assets/css/build-log.css
+++ b/assets/css/build-log.css
@@ -1,0 +1,35 @@
+/* build-log.css */
+.log-container {
+  max-width: 800px;
+  margin: 80px auto 48px;
+  padding: 0 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+.log-title {
+  font-size: 2rem;
+  color: #b07b8c;
+  text-align: center;
+  text-transform: lowercase;
+  font-family: 'Playfair Display', serif;
+}
+.changelog {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.log-card {
+  background: var(--bg-card);
+  padding: 1rem 1.2rem;
+  border-radius: 10px;
+  box-shadow: 0 4px 20px rgba(0,0,0,0.1);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 1rem;
+}
+.log-date {
+  font-size: 0.9rem;
+  color: var(--text-accent);
+}

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -659,7 +659,7 @@ main, .work-gallery-container, .work-gallery, .project-card {
 button,
 input[type="button"],
 input[type="submit"],
-.theme-toggle,
+.theme-switch,
 .nav-hamburger,
 .footer-link,
 .contact-form button {
@@ -676,7 +676,7 @@ input[type="submit"],
 body.light button,
 body.light input[type="button"],
 body.light input[type="submit"],
-body.light .theme-toggle,
+body.light .theme-switch,
 body.light .nav-hamburger,
 body.light .footer-link,
 body.light .contact-form button {
@@ -684,18 +684,54 @@ body.light .contact-form button {
   color: #222 !important;
 }
 
+body.light .theme-switch .slider {
+  background: #e5e5e5;
+}
+
 /* Theme toggle specific overrides */
-.theme-toggle {
+.theme-switch {
   position: absolute;
   top: 14px;
   right: 24px;
   z-index: 200;
-  font-size: 1.5rem;
+  display: inline-flex;
+  align-items: center;
+}
+
+.theme-switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.theme-switch .slider {
+  width: 44px;
+  height: 24px;
+  background: #444;
+  border-radius: 34px;
+  position: relative;
   cursor: pointer;
-  color: var(--text-accent) !important;
+  transition: background 0.18s;
+}
+
+.theme-switch .slider::before {
+  content: "";
+  position: absolute;
+  width: 18px;
+  height: 18px;
+  left: 3px;
+  top: 3px;
+  background: #fff;
   border-radius: 50%;
-  padding: 6px 10px;
-  outline: none;
+  transition: transform 0.18s;
+}
+
+input#theme-toggle:checked + .slider {
+  background: #b07b8c;
+}
+
+input#theme-toggle:checked + .slider::before {
+  transform: translateX(20px);
 }
 
 /* Hamburger icon button (nav-mobile) */
@@ -748,8 +784,8 @@ input[type="button"]:hover,
 input[type="button"]:focus,
 input[type="submit"]:hover,
 input[type="submit"]:focus,
-.theme-toggle:hover,
-.theme-toggle:focus,
+.theme-switch .slider:hover,
+.theme-switch .slider:focus,
 .nav-hamburger:hover,
 .nav-hamburger:focus,
 .footer-link:hover,

--- a/assets/js/components.js
+++ b/assets/js/components.js
@@ -173,9 +173,9 @@ document.addEventListener('DOMContentLoaded', async function() {
             document.body.classList.add('dark');
             document.body.style.background = "url('/assets/images/background.gif') center center/cover no-repeat fixed, #ffe5ec";
         }
-        const toggleBtn = document.getElementById('theme-toggle');
-        if (toggleBtn) {
-            toggleBtn.textContent = theme === 'light' ? '🌞' : '🌙';
+        const toggleInput = document.getElementById('theme-toggle');
+        if (toggleInput && toggleInput.type === 'checkbox') {
+            toggleInput.checked = theme === 'light';
         }
     }
     function getPreferredTheme() {
@@ -189,12 +189,20 @@ document.addEventListener('DOMContentLoaded', async function() {
         let theme = getPreferredTheme();
         applyTheme(theme);
         if (themeToggle) {
-            themeToggle.textContent = theme === 'light' ? '🌞' : '🌙';
-            themeToggle.onclick = function() {
-                theme = document.body.classList.contains('light') ? 'dark' : 'light';
-                localStorage.setItem('theme', theme);
-                applyTheme(theme);
-            };
+            if (themeToggle.type === 'checkbox') {
+                themeToggle.checked = theme === 'light';
+                themeToggle.addEventListener('change', function() {
+                    theme = this.checked ? 'light' : 'dark';
+                    localStorage.setItem('theme', theme);
+                    applyTheme(theme);
+                });
+            } else {
+                themeToggle.onclick = function() {
+                    theme = document.body.classList.contains('light') ? 'dark' : 'light';
+                    localStorage.setItem('theme', theme);
+                    applyTheme(theme);
+                };
+            }
         }
     }
     // Run after header is loaded

--- a/build-log.html
+++ b/build-log.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <title>Kiara Raab | build log</title>
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🩷</text></svg>" />
+    <link rel="stylesheet" href="assets/css/index.css">
+    <link rel="stylesheet" href="assets/css/build-log.css">
+    <link rel="stylesheet" href="assets/css/contact.css">
+    <link rel="stylesheet" href="assets/css/nav-mobile.css">
+</head>
+<body class="build-log-page">
+    <div id="header-placeholder"></div>
+    <main class="log-container">
+        <h1 class="log-title">build with me</h1>
+        <div class="changelog">
+            <div class="log-card">
+                <div class="log-text">🎉 added light mode toggle</div>
+                <div class="log-date">June 30, 2024</div>
+            </div>
+            <div class="log-card">
+                <div class="log-text">✨ polished design and animations</div>
+                <div class="log-date">May 15, 2024</div>
+            </div>
+            <div class="log-card">
+                <div class="log-text">🚀 initial site launch</div>
+                <div class="log-date">May 1, 2024</div>
+            </div>
+        </div>
+    </main>
+    <div id="footer-placeholder"></div>
+    <script src="assets/js/components.js"></script>
+    <script src="assets/js/time-diff.js"></script>
+</body>
+</html>

--- a/components/header.html
+++ b/components/header.html
@@ -12,6 +12,7 @@
             <ul class="nav-dropdown-list">
                 <li><a href="/about.html" data-page="about">about</a></li>
                 <li><a href="/resume.html" data-page="resume">résumé</a></li>
+                <li><a href="/build-log.html" data-page="build-log">build log</a></li>
             </ul>
         </nav>
     </div>
@@ -19,6 +20,9 @@
         <div class="header-info">
             <div id="time-status"></div>
         </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark/light mode">🌙</button>
+        <label class="theme-switch">
+            <input type="checkbox" id="theme-toggle" aria-label="Toggle dark/light mode">
+            <span class="slider"></span>
+        </label>
     </div>
 </header>


### PR DESCRIPTION
## Summary
- use a switch-style theme toggle and add build log link in the header
- update theme logic for the new checkbox
- style the theme switch in CSS
- create a build log page with dated cards

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68601457e03c83309d11efad851fe8ff